### PR TITLE
Fixes bug when result set has NULL

### DIFF
--- a/src/edu/northeastern/khoury/SQLiteDiff.java
+++ b/src/edu/northeastern/khoury/SQLiteDiff.java
@@ -73,7 +73,7 @@ public class SQLiteDiff {
 			}
 			
 			for (int i=1; i<=expected.length; i++) {
-				final String val = rs.getObject(i).toString();
+				final String val = rs.getObject(i) != null ? rs.getObject(i).toString() : "";
 				if (!val.equals(expected[i-1])) {
 					return String.format("Value for <%s> incorrect: expected=\"%s\", actual=\"%s\"%n", rs.getMetaData().getColumnLabel(i), expected[i-1], val);
 				}


### PR DESCRIPTION
If a query result set has a NULL for a column i,  attempting to getObject(i) gives a  null object references and this leads to a NullPointerException. The fix is to have this column value be an empty String, as that matches how the CSV file is parsed when there's no value for that column.